### PR TITLE
Casual Inhouse Queue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,13 @@ RUN apt-get update \
 
 WORKDIR /bot
 
-# Copy files to work directory
-COPY bot.py ./
-COPY ./inhouse ./inhouse
 COPY requirements.txt .
 
 RUN pip3 install -r requirements.txt
+
+# Copy src files to work directory
+COPY bot.py ./
+COPY ./inhouse ./inhouse
 
 EXPOSE 443
 

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,7 @@ import discord
 from discord.ext import commands
 import re
 import os
-
+from inhouse.command_handlers.causal_modes import CasualModePicker
 from inhouse.command_handlers.player import Player
 from riotwatcher import LolWatcher, ApiError
 
@@ -309,6 +309,12 @@ async def setname(ctx, summoner_name: str):
             await ctx.respond(f"<@&{bot_dev_role}> needs to update riot API key. Please reachout to Staff to fix.")
             return
         await ctx.respond(summoner_name + " is not a summoner name")
+
+@commands.has_role("Staff")
+@bot.slash_command(description="casual game modes")
+async def casual(ctx: discord.ApplicationContext):
+    await ctx.respond("Choose the modes you'd like to play!")
+    await ctx.send("Casual games", view=CasualModePicker(timeout=30))
 
 @bot.event
 async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):

--- a/inhouse-init.sql
+++ b/inhouse-init.sql
@@ -97,7 +97,6 @@ CREATE TABLE "public"."players" (
     "name" character varying(50) NOT NULL,
     "win" integer NOT NULL,
     "loss" integer NOT NULL,
-    "ratio" integer NOT NULL,
     "sp" integer NOT NULL
 );
 ALTER TABLE public.players OWNER TO utahesports;

--- a/inhouse/command_handlers/causal_modes.py
+++ b/inhouse/command_handlers/causal_modes.py
@@ -1,33 +1,38 @@
 import discord
-from inhouse.constants import *
+import inhouse.constants
+from inhouse.command_handlers.queue import Queue
 
 class CasualModePicker(discord.ui.View):
-    async def on_timeout(self):
+    def __init__(self, *items, timeout = 180, ctx: discord.ApplicationContext):
+        super().__init__(*items, timeout=timeout)
+        self.ctx = ctx
+
+    @discord.ui.button(label="Casual Inhouse", style=discord.ButtonStyle.primary, emoji="⚔️")
+    async def casual_inhouse_callback(self, button, interaction):
+        await self.disable_buttons(interaction)
+        print("Chose Casual Inhouses")
+        if inhouse.constants.casual_queue != None:
+            await inhouse.constants.casual_queue.queue_message.reply("Queue is already open! React to the above message")
+            return
+        inhouse.constants.casual_queue = Queue(ctx=self.ctx)
+        await inhouse.constants.casual_queue.create_queue_message(inhouse.constants.server_roles.casual_inhouse)
+        
+    # @discord.ui.button(label="Normal Game", style=discord.ButtonStyle.primary, emoji="♻️")
+    # async def normal_game_callback(self, button, interaction):
+    #     await self.disable_buttons(interaction)
+    #     print("Chose Norms")
+
+    # @discord.ui.button(label="ARAM", style=discord.ButtonStyle.primary, emoji="♻️")
+    # async def aram_callback(self, button, interaction):
+    #     await self.disable_buttons(interaction)
+    #     print("Chose ARAM")
+
+    # @discord.ui.button(label="FLEX", style=discord.ButtonStyle.primary, emoji="♻️")
+    # async def flex_callback(self, button, interaction):
+    #     await self.disable_buttons(interaction)
+    #     print("Chose Flex")
+
+    async def disable_buttons(self, interaction):
         for child in self.children:
             child.disabled = True
-        await self.message.edit(content="You took too long! Disabled all the components.", view=self)
-
-    @discord.ui.select(
-        placeholder = "Choose on or more game type!",
-        min_values = 1,
-        max_values = 3,
-        options = [
-            discord.SelectOption(
-                label="ARAM",
-                # emoji=f"<:ARAM:{top_emoji_id}>"
-                emoji=f"<:Top:{top_emoji_id}>"
-            ),
-            discord.SelectOption(
-                label="TFT",
-                #emoji=f"<:TFT:{mid_emoji_id}>"
-                emoji=f"<:jungle:{jg_emoji_id}>"
-            ),
-            discord.SelectOption(
-                label="Normals",
-                #emoji=f"<:POGGIES~1:{jg_emoji_id}"
-                emoji=f"<:Mid:{mid_emoji_id}>"
-            )
-        ]
-    )
-    async def select_callback(self, select, interaction):
-        await interaction.response.send_message(f"You picked {select.values}")
+        await interaction.response.edit_message(view=self)  

--- a/inhouse/command_handlers/causal_modes.py
+++ b/inhouse/command_handlers/causal_modes.py
@@ -1,0 +1,33 @@
+import discord
+from inhouse.constants import *
+
+class CasualModePicker(discord.ui.View):
+    async def on_timeout(self):
+        for child in self.children:
+            child.disabled = True
+        await self.message.edit(content="You took too long! Disabled all the components.", view=self)
+
+    @discord.ui.select(
+        placeholder = "Choose on or more game type!",
+        min_values = 1,
+        max_values = 3,
+        options = [
+            discord.SelectOption(
+                label="ARAM",
+                # emoji=f"<:ARAM:{top_emoji_id}>"
+                emoji=f"<:Top:{top_emoji_id}>"
+            ),
+            discord.SelectOption(
+                label="TFT",
+                #emoji=f"<:TFT:{mid_emoji_id}>"
+                emoji=f"<:jungle:{jg_emoji_id}>"
+            ),
+            discord.SelectOption(
+                label="Normals",
+                #emoji=f"<:POGGIES~1:{jg_emoji_id}"
+                emoji=f"<:Mid:{mid_emoji_id}>"
+            )
+        ]
+    )
+    async def select_callback(self, select, interaction):
+        await interaction.response.send_message(f"You picked {select.values}")

--- a/inhouse/command_handlers/causal_modes.py
+++ b/inhouse/command_handlers/causal_modes.py
@@ -1,26 +1,31 @@
 import discord
 import inhouse.constants
-from inhouse.command_handlers.queue import Queue
+from inhouse.command_handlers.queue import Queue, AramQueue
 
 class CasualModePicker(discord.ui.View):
     def __init__(self, *items, timeout = 180, ctx: discord.ApplicationContext):
         super().__init__(*items, timeout=timeout)
         self.ctx = ctx
 
-    @discord.ui.button(label="Casual Inhouse", style=discord.ButtonStyle.primary, emoji="⚔️")
+    @discord.ui.button(label="Casual Inhouse - SR", style=discord.ButtonStyle.primary, emoji="⚔️")
     async def casual_inhouse_callback(self, button, interaction):
         await self.disable_buttons(interaction)
-        print("Chose Casual Inhouses")
-        if inhouse.constants.casual_queue != None:
-            await inhouse.constants.casual_queue.queue_message.reply("Queue is already open! React to the above message")
+        print("Chose Casual Inhouses SR")
+        if inhouse.global_objects.casual_queue != None:
+            await inhouse.global_objects.casual_queue.queue_message.reply("Queue is already open! React to the above message")
             return
-        inhouse.constants.casual_queue = Queue(ctx=self.ctx)
-        await inhouse.constants.casual_queue.create_queue_message(inhouse.constants.server_roles.casual_inhouse)
+        inhouse.global_objects.casual_queue = Queue(ctx=self.ctx)
+        await inhouse.global_objects.casual_queue.create_queue_message(inhouse.constants.server_roles.casual_inhouse)
         
-    # @discord.ui.button(label="Normal Game", style=discord.ButtonStyle.primary, emoji="♻️")
-    # async def normal_game_callback(self, button, interaction):
-    #     await self.disable_buttons(interaction)
-    #     print("Chose Norms")
+    @discord.ui.button(label="Casual Inhouse - ARAM", style=discord.ButtonStyle.primary, emoji=f"<:ARAM:{inhouse.constants.aram_emoji_id}>")
+    async def normal_game_callback(self, button, interaction):
+        await self.disable_buttons(interaction)
+        print("Chose Casual Inhouses ARAM")
+        if inhouse.global_objects.casual_queue_aram != None:
+            await inhouse.global_objects.casual_queue_aram.queue_message.reply("Queue is already open! React to the above message")
+            return
+        inhouse.global_objects.casual_queue_aram = AramQueue(ctx=self.ctx)
+        await inhouse.global_objects.casual_queue_aram.create_queue_message(inhouse.constants.server_roles.casual_inhouse)
 
     # @discord.ui.button(label="ARAM", style=discord.ButtonStyle.primary, emoji="♻️")
     # async def aram_callback(self, button, interaction):

--- a/inhouse/command_handlers/match.py
+++ b/inhouse/command_handlers/match.py
@@ -281,3 +281,91 @@ class ActiveMatch(object):
         Red Team: {self.red_team}
         Thread ID: {self.thread.id}""")
 
+# TODO: should overhaul this subclassing, lots of overrides/repeated code currently
+
+class ActiveMatchARAM(ActiveMatch):
+    def __init__(self, db_handler: DatabaseHandler, competitive: bool = False) -> None:
+        super().__init__(db_handler, competitive)
+        self.blue_team = []
+        self.red_team = []
+        self.match_id = ""
+
+    async def begin(self, players: dict, ctx, madeMatch: bool = False) -> discord.Message:
+        teams = self.choose_teams(all_players=players, madeMatch=madeMatch)
+        self.blue_team = teams['blue']
+        self.red_team = teams['red']
+        # we skip DB entries for aram games
+        return await self.create_match_thread(ctx)
+
+    def choose_teams(self, all_players: dict, madeMatch: bool = False) -> dict:
+        players = all_players["all"]
+        print(players)
+        red_team = []
+        shuffled_players = random.sample(players, len(players))
+        for _ in range(0,5):
+            red_team.append(shuffled_players.pop(0))
+        blue_team = shuffled_players
+        return {'blue': blue_team, 'red': red_team}
+
+    async def send_match_description(self):
+        msg = discord.Embed(description = "```ARAM!```",color=discord.Color.gold())
+
+        blue_string = ""
+        red_string = ""
+        ping_string = ""
+        for player in self.blue_team:
+            blue_string += f"{player.name}\n"
+            ping_string += f"<@{player.id}> "
+        for player in self.red_team:
+            red_string += f"{player.name}\n"
+            ping_string += f"<@{player.id}> "
+
+        msg.add_field(name="Blue Team", value=blue_string.strip(), inline=True)
+        msg.add_field(name="Red Team", value=red_string.strip(), inline=True)
+        match_desc = await self.thread.send(embed=msg)
+
+        # unpin old (if applicable) and pin new
+        if self.match_description_message != None:
+            await self.match_description_message.unpin()
+        else:
+            # send the ping string if this is the first match desc
+            await self.thread.send(ping_string)
+
+        await match_desc.pin()
+        self.match_description_message = match_desc
+    
+    def get_all_players(self) -> list:
+        return [player for player in self.blue_team] + [player for player in self.red_team]
+
+    async def move_to_channels(self, ctx: discord.context.ApplicationContext):
+        await asyncio.sleep(move_to_channel_delay)
+        blue_channel_id, red_channel_id = self.get_empty_channels(ctx)
+        if blue_channel_id == "" or red_channel_id == "":
+            self.thread.send("No Inhouse Channels Open")
+            return
+        ping_channel_string = ""
+        for blue_player in self.blue_team:
+            member = ctx.guild.get_member(blue_player.id) 
+            channel = ctx.guild.get_channel(blue_channel_id)
+            print(f"member: {member}, channel: {channel}")
+            ping_channel_string += await self.send_channel(member,channel)
+        for red_player in self.red_team:
+            member = ctx.guild.get_member(red_player.id) 
+            channel = ctx.guild.get_channel(red_channel_id) 
+            print(f"member: {member}, channel: {channel}")
+            ping_channel_string += await self.send_channel(member,channel)
+        if ping_channel_string != "":
+            await self.thread.send(ping_channel_string)
+
+    async def complete_match(self, winner: str):
+        # real simple in the aram case, just send the tropy and delete the original message
+        msg = discord.Embed(description=f":trophy: {winner.upper()} WINS! :trophy:", color=discord.Color.gold())
+        await self.thread.send(embed=msg)
+        await self.original_thread_message.delete()
+
+    async def send_match_report_result(self) -> discord.Message:
+        who_won = discord.Embed(description="Who Won?", color=discord.Color.gold())
+        won_message = await self.thread.send(embed=who_won)
+        await won_message.add_reaction("🟦")
+        await won_message.add_reaction("🟥")
+        return won_message

--- a/inhouse/command_handlers/queue.py
+++ b/inhouse/command_handlers/queue.py
@@ -162,7 +162,7 @@ class Queue(object):
         await match_to_finish.complete_match(winner)
         self.played_matches += 1
 
-        if main_leaderboard != None:
+        if main_leaderboard != None and self.is_competitive_queue:
             await main_leaderboard.update_leaderboard()
         elif self.is_competitive_queue:
             # only send this if it's a competitive queue, otherwise just ignore (casual games have no leaderboard)

--- a/inhouse/constants.py
+++ b/inhouse/constants.py
@@ -1,3 +1,16 @@
+from dis import disco
+import discord
+from queue import Queue
+
+class RolesHolder():
+    def __init__(self, competitive_inhouse: discord.Role, casual_inhouse: discord.Role, normals: discord.Role, flex: discord.Role, aram: discord.Role, rgm: discord.Role) -> None:
+        self.competitive_inhouse = competitive_inhouse
+        self.casual_inhouse = casual_inhouse
+        self.normals = normals
+        self.flex = flex
+        self.aram = aram
+        self.rgm = rgm
+
 # MARK: IDs
 top_emoji_id = 1003021609239588875
 jg_emoji_id = 1003014949196546150
@@ -38,4 +51,6 @@ win_points = 15
 loss_points = 12
 move_to_channel_delay = 30
 
-
+casual_queue: Queue = None
+server_roles: RolesHolder = None
+main_queue: Queue = None

--- a/inhouse/constants.py
+++ b/inhouse/constants.py
@@ -1,15 +1,4 @@
-from dis import disco
 import discord
-from queue import Queue
-
-class RolesHolder():
-    def __init__(self, competitive_inhouse: discord.Role, casual_inhouse: discord.Role, normals: discord.Role, flex: discord.Role, aram: discord.Role, rgm: discord.Role) -> None:
-        self.competitive_inhouse = competitive_inhouse
-        self.casual_inhouse = casual_inhouse
-        self.normals = normals
-        self.flex = flex
-        self.aram = aram
-        self.rgm = rgm
 
 # MARK: IDs
 top_emoji_id = 1003021609239588875
@@ -18,6 +7,8 @@ mid_emoji_id = 1003024543494963220
 bot_emoji_id = 1003022277631283240
 supp_emoji_id = 1003027602698670282
 all_role_emojis = [top_emoji_id, jg_emoji_id, mid_emoji_id, bot_emoji_id, supp_emoji_id]
+
+aram_emoji_id = 1009563351946371102
 
 soulrush_bot_id = 197473689263013898
 
@@ -51,6 +42,3 @@ win_points = 15
 loss_points = 12
 move_to_channel_delay = 30
 
-casual_queue: Queue = None
-server_roles: RolesHolder = None
-main_queue: Queue = None

--- a/inhouse/global_objects.py
+++ b/inhouse/global_objects.py
@@ -1,0 +1,15 @@
+from inhouse.command_handlers.queue import *
+
+class RolesHolder():
+    def __init__(self, competitive_inhouse: discord.Role, casual_inhouse: discord.Role, normals: discord.Role, flex: discord.Role, aram: discord.Role, rgm: discord.Role) -> None:
+        self.competitive_inhouse = competitive_inhouse
+        self.casual_inhouse = casual_inhouse
+        self.normals = normals
+        self.flex = flex
+        self.aram = aram
+        self.rgm = rgm
+
+casual_queue: Queue = None
+casual_queue_aram: AramQueue = None
+server_roles: RolesHolder = None
+main_queue: Queue = None


### PR DESCRIPTION
- lays groundwork view component for other casual modes
- Adds the ability to start a casual inhouse queue for (individual users may do so, only 1 queue may be active at a time)
- Queue must still be stopped or manually deleted by staff at this point but will remain open indefinitely.
- Casual matches do not interact with the database other than an `active_matches` entry. No players or history is stored.

I would like to add the ability to track casual inhouse matches as well, but it will require a good chunk of database schema changes. Since I am already adding a bunch of database changes with the coin feature, I'm planning on lumping the casual inhouse db updates in with that.