### PR TITLE
Queue Button Overhaul

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,5 @@ services:
       POSTGRES_USER: utahesports
       POSTGRES_PASSWORD: starforger
       POSTGRES_DB: inhouse-bot-db
-    # volumes:
-    #   - db_data:/var/lib/postgresql/data/pgdata
+    ports: 
+      - 6789:5432

--- a/inhouse/command_handlers/match.py
+++ b/inhouse/command_handlers/match.py
@@ -246,8 +246,8 @@ class ActiveMatch(object):
             for key in roles:
                 player_ids_str += f"'{str(self.blue_team[key].id)}','{str(self.red_team[key].id)}',"
 
-                # strip last comma and insert
-                cmd = f"INSERT INTO active_matches({all_roles_db_key}) VALUES ({player_ids_str.strip(',')}) RETURNING active_id"
+            # strip last comma and insert
+            cmd = f"INSERT INTO active_matches({all_roles_db_key}) VALUES ({player_ids_str.strip(',')}) RETURNING active_id"
 
         cur = self.db_handler.get_cursor()
         cur.execute(cmd)

--- a/inhouse/command_handlers/queue.py
+++ b/inhouse/command_handlers/queue.py
@@ -217,3 +217,8 @@ class AramQueue(Queue):
 
     def all_queued_player_ids(self) -> list:
         return [player.id for player in self.queued_players["all"]]
+
+class QueueJoin(discord.ui.View):
+    def __init__(self, queue: Queue):
+        super().__init__(timeout=None)
+        self.queue = queue

--- a/inhouse/db_util.py
+++ b/inhouse/db_util.py
@@ -37,7 +37,7 @@ class DatabaseHandler:
 
     async def get_soloq_entry_by_name(self, name: str):
         cur = self.get_cursor()
-        cmd = f"SELECT discord_id FROM soloqueue_leaderboard where name = {name}"
+        cmd = f"SELECT discord_id FROM soloqueue_leaderboard where league_name = {name}"
         cur.execute(cmd)
         id_entry = cur.fetchone()
         return id_entry[0]

--- a/inhouse/global_objects.py
+++ b/inhouse/global_objects.py
@@ -17,3 +17,5 @@ server_roles: RolesHolder = None
 main_queue: Queue = None
 watcher = LolWatcher(os.environ.get('Riot_Api_Key'))
 coin_manager: CoinManager = None
+main_leaderboard: Leaderboard = None
+solo_queue_leaderboard: Leaderboard = None


### PR DESCRIPTION
- Inhouses now use buttons to queue/report match winners instead of reactions, which is much easier for us to handle
- A bunch of exception handling
- Added some small functionality to soloqueue leaderboard:
    - All players now gain 1 coin per 10LP positive gain every week
    - Top 3 most gains per week get the same amount as top 3 overall