### PR TITLE
temp fix: reorder calls to not timeout response when match is created

### DIFF
--- a/inhouse/command_handlers/match.py
+++ b/inhouse/command_handlers/match.py
@@ -389,8 +389,6 @@ class ActiveMatchARAM(ActiveMatch):
         await self.thread.send(embed=who_won, view=ReportMatchResult(match=self))
 
 
-
-
 class ReportMatchResult(discord.ui.View):
     def __init__(self, match: ActiveMatch):
         super().__init__(timeout=None)
@@ -405,7 +403,7 @@ class ReportMatchResult(discord.ui.View):
                     inhouse.global_objects.main_queue.active_matches.remove(self.match)
                     if inhouse.global_objects.main_leaderboard != None:
                         await inhouse.global_objects.main_leaderboard.update_leaderboard()
-                        await interaction.response.defer()
+                        await interaction.response.send_message(f"Match recorded.", ephemeral=True)
                     else:
                         await interaction.response.send_message("Match has been recorded but Leaderboard channel is not set, ask Staff to set it!")
             elif not self.match.is_competitive_match:
@@ -414,10 +412,10 @@ class ReportMatchResult(discord.ui.View):
                     inhouse.global_objects.casual_queue_aram.active_matches.remove(self.match)
                 else:
                     inhouse.global_objects.casual_queue.active_matches.remove(self.match)
-                await interaction.response.defer()
+                await interaction.response.send_message(f"Match completed.", ephemeral=True)
             else:
                 print("unhandled match case")
-                await interaction.response.defer()
+                await interaction.response.send_message("Unknown match completion attempted. Please reach out to staff.")
         except Exception as e:
             print(e)
             await interaction.response.send_message("Something went wrong! Please try again. If the issue persists, reach out to Staff.", ephemeral=True)

--- a/inhouse/command_handlers/queue.py
+++ b/inhouse/command_handlers/queue.py
@@ -184,6 +184,8 @@ class Queue(object):
             keep_players = list(filter(lambda player: player.id not in match_player_ids and player.id != -1, [player for player in self.queued_players[role]]))
             self.queued_players[role] = keep_players
             
+        await self.update_queue_message()
+
         # create and begin match
         new_match = ActiveMatch(db_handler=self.db_handler, competitive=self.is_competitive_queue)
         new_match.is_test_match = is_test
@@ -191,7 +193,6 @@ class Queue(object):
 
         # Add this match to the queue's tracker
         self.active_matches.append(new_match)
-        await self.update_queue_message()
     
     async def update_queue_message(self):
         msg_str = f'''```QUEUE```
@@ -255,8 +256,8 @@ class InhouseQueueJoin(discord.ui.View):
     
     async def add_to_queue(self, interaction: discord.Interaction, role: str):
         try:
-            await self.queue.add_player_to_queue(Player(id=interaction.user.id, name=interaction.user.display_name, db_handler=self.queue.db_handler), role=role)
             await interaction.response.send_message(f"Joined the queue as {role}", ephemeral=True)
+            await self.queue.add_player_to_queue(Player(id=interaction.user.id, name=interaction.user.display_name, db_handler=self.queue.db_handler), role=role)
         except Exception as e:
             print(e)
             await interaction.response.send_message("Something went wrong! Please try again. If the issue persists, reach out to Staff.", ephemeral=True)

--- a/inhouse/db_util.py
+++ b/inhouse/db_util.py
@@ -37,7 +37,7 @@ class DatabaseHandler:
 
     async def get_soloq_entry_by_name(self, name: str):
         cur = self.get_cursor()
-        cmd = f"SELECT discord_id FROM soloqueue_leaderboard where league_name = {name}"
+        cmd = f"SELECT discord_id FROM soloqueue_leaderboard where league_name = '{name}'"
         cur.execute(cmd)
         id_entry = cur.fetchone()
         return id_entry[0]


### PR DESCRIPTION
In the long run we should dispatch the voice channel moves to background threads